### PR TITLE
reword word_count instructions

### DIFF
--- a/applications/word_count/README.md
+++ b/applications/word_count/README.md
@@ -28,4 +28,4 @@ Ignore each of the following characters:
 " : ; , . - + = / \ | [ ] { } ( ) * ^ &
 ```
 
-If the input contains no ignored characters, return an empty dictionary.
+If a "word" contains only ignored characters, do not add it to the dictionary.


### PR DESCRIPTION
The current instructions say that if the *input* does contain ignored characters, the function should return an empty dictionary. However, implementing this fails the test on line 12; "Hello     hello" contains no ignored characters, so according to the current instructions, an empty dictionary should be returned. My proposed amendment is what I believe the instructions are intending to say.

See issue https://github.com/LambdaSchool/cs-module-project-hash-tables/issues/12